### PR TITLE
Cronet DNS, DoH overrides to enable ECH from GreatFire Envoy

### DIFF
--- a/components/cronet/url_request_context_config.cc
+++ b/components/cronet/url_request_context_config.cc
@@ -211,6 +211,10 @@ const char kDisableTlsZeroRtt[] = "disable_tls_zero_rtt";
 // underlying OS.
 const char kSpdyGoAwayOnIpChange[] = "spdy_go_away_on_ip_change";
 
+// Use a StandaloneResolver with the provided DNS over HTTPS configs. Other
+// values are left at the defaults. TODO: Should we offer more of the config?
+const char kDnsOverHttpsConfig[] = "dns_over_https_config";
+
 // Whether the connection status of all bidirectional streams (created through
 // the Cronet engine) should be monitored.
 // The value must be an integer (> 0) and will be interpreted as a suggestion
@@ -765,6 +769,30 @@ void URLRequestContextConfig::SetContextBuilderExperimentalOptions(
         continue;
       }
       session_params->spdy_go_away_on_ip_change = iter->second.GetBool();
+    } else if (iter->first == kDnsOverHttpsConfig) {
+      if (!iter->second.is_dict()) {
+        LOG(ERROR) << "\"" << iter->first << "\" config params \""
+                   << iter->second << "\" is not a dictionary value";
+        effective_experimental_options.Remove(iter->first);
+        continue;
+      }
+
+      net::DnsConfigOverrides overrides = net::DnsConfigOverrides::CreateOverridingEverythingWithDefaults();
+      // Envoy does this
+      overrides.secure_dns_mode = net::SecureDnsMode::kSecure;
+
+      // This is a little silly, Dict -> JSON -> Dict
+      std::string temp;
+      base::JSONWriter::Write(iter->second.GetDict(), &temp);
+      overrides.dns_over_https_config = net::DnsOverHttpsConfig::FromString(temp);
+
+      net::HostResolver::ManagerOptions host_resolver_manager_options;
+      host_resolver_manager_options.dns_config_overrides = overrides;
+      std::unique_ptr<net::HostResolver> host_resolver;
+      host_resolver = net::HostResolver::CreateStandaloneResolver(
+        net::NetLog::Get(), std::move(host_resolver_manager_options));
+
+      context_builder->set_host_resolver(std::move(host_resolver));
     } else {
       LOG(WARNING) << "Unrecognized Cronet experimental option \""
                    << iter->first << "\" with params \"" << iter->second;


### PR DESCRIPTION
## Who and why?

See the notes on: https://github.com/stevenmcdonald/chromium/pull/5

---

# DNS / DoH options

The goal of this feature was to enable ECH. To do that, we needed enable and configure the StandaloneResolver, and apply it to the context builder. We only need to override the `dns_over_https_config` for our purposes, that's what this patch does, though we could expose more of the `net::DnsConfigOverrides` options if that would be useful

Similar questions/comments to https://github.com/stevenmcdonald/chromium/pull/5:

* Does Google want this feature
* This one uses experimental_options, would it be preferable as a param?
* Specific this this one: Should we make more of the `net::DnsConfigOverrides` settable?